### PR TITLE
Fixed ExcludeList function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 SkipList.txt
 ProtectList.txt
 IncludeList.txt
+ExcludePaths.txt

--- a/DeployCryptoBlocker.ps1
+++ b/DeployCryptoBlocker.ps1
@@ -305,10 +305,15 @@ $drivesContainingShares | ForEach-Object {
 }
 
 # Add Folder Exceptions from ExcludeList.txt
-If (Test-Path .\ExcludePaths.txt) {
-    Write-Host "`n####"
-    Write-Host "Processing Folder Exclusions.."
-    Get-Content .\ExcludePaths.txt | ForEach-Object {
+Write-Host "`n####"
+Write-Host "Processing ExcludeList.."
+### move file from C:\Windows\System32 or whatever your relative path is to the directory of this script
+if (Test-Path .\ExcludePaths.txt)
+{
+    Move-Item -Path .\ExcludePaths.txt -Destination $PSScriptRoot\ExcludePaths.txt -Force
+}
+If (Test-Path $PSScriptRoot\ExcludePaths.txt) {
+    Get-Content $PSScriptRoot\ExcludePaths.txt | ForEach-Object {
         If (Test-Path $_) {
             # Build the argument list with all required fileGroups
             $ExclusionArgs = 'Exception', 'Add', "/Path:$_"

--- a/DeployCryptoBlocker.ps1
+++ b/DeployCryptoBlocker.ps1
@@ -221,9 +221,9 @@ $monitoredExtensions = @(ConvertFrom-Json20 $jsonStr | ForEach-Object { $_.filte
 Write-Host "`n####"
 Write-Host "Processing SkipList.."
 ### move file from C:\Windows\System32 or whatever your relative path is to the directory of this script
-if (Test-Path .\ProtectList.txt)
+if (Test-Path .\SkipList.txt)
 {
-    Move-Item -Path .\ProtectList.txt -Destination $PSScriptRoot\ProtectList.txt -Force
+    Move-Item -Path .\SkipList.txt -Destination $PSScriptRoot\SkipList.txt -Force
 }
 
 If (Test-Path $PSScriptRoot\SkipList.txt)

--- a/DeployCryptoBlocker.ps1
+++ b/DeployCryptoBlocker.ps1
@@ -316,11 +316,13 @@ If (Test-Path $PSScriptRoot\ExcludePaths.txt) {
     Get-Content $PSScriptRoot\ExcludePaths.txt | ForEach-Object {
         If (Test-Path $_) {
             # Build the argument list with all required fileGroups
-            $ExclusionArgs = 'Exception', 'Add', "/Path:$_"
+            $ExclusionArgs = @()
             ForEach ($group in $fileGroups) {
                 $ExclusionArgs += "/Add-Filegroup:$($group.fileGroupName)"
             }
-            &filescrn.exe $ExclusionArgs
+            Write-Host "File Exeption for [$_] with Args [$ExclusionArgs].."
+            &filescrn.exe Exception Delete "/Path:$_" /Quiet
+            &filescrn.exe Exception Add "/Path:$_" $ExclusionArgs
         }
     }
 }

--- a/DeployCryptoBlocker.ps1
+++ b/DeployCryptoBlocker.ps1
@@ -179,9 +179,17 @@ else
 }
 
 ## Enumerate shares
+Write-Host "`n####"
+Write-Host "Processing ProtectList.."
+### move file from C:\Windows\System32 or whatever your relative path is to the directory of this script
 if (Test-Path .\ProtectList.txt)
 {
-    $drivesContainingShares = Get-Content .\ProtectList.txt | ForEach-Object { $_.Trim() }
+    Move-Item -Path .\ProtectList.txt -Destination $PSScriptRoot\ProtectList.txt -Force
+}
+
+if (Test-Path $PSScriptRoot\ProtectList.txt)
+{
+    $drivesContainingShares = Get-Content $PSScriptRoot\ProtectList.txt | ForEach-Object { $_.Trim() }
 }
 Else {
     $drivesContainingShares =   @(Get-WmiObject Win32_Share | 
@@ -212,6 +220,12 @@ $monitoredExtensions = @(ConvertFrom-Json20 $jsonStr | ForEach-Object { $_.filte
 # Process SkipList.txt
 Write-Host "`n####"
 Write-Host "Processing SkipList.."
+### move file from C:\Windows\System32 or whatever your relative path is to the directory of this script
+if (Test-Path .\ProtectList.txt)
+{
+    Move-Item -Path .\ProtectList.txt -Destination $PSScriptRoot\ProtectList.txt -Force
+}
+
 If (Test-Path $PSScriptRoot\SkipList.txt)
 {
     $Exclusions = Get-Content $PSScriptRoot\SkipList.txt | ForEach-Object { $_.Trim() }
@@ -238,9 +252,16 @@ Else
 }
 
 # Check to see if we have any local patterns to include
-If (Test-Path .\IncludeList.txt)
+Write-Host "`n####"
+Write-Host "Processing IncludeList.."
+### move file from C:\Windows\System32 or whatever your relative path is to the directory of this script
+if (Test-Path .\IncludeList.txt)
 {
-    $includeExt = Get-Content .\IncludeList.txt | ForEach-Object { $_.Trim() }
+    Move-Item -Path .\IncludeList.txt -Destination $PSScriptRoot\IncludeList.txt -Force
+}
+If (Test-Path $PSScriptRoot\IncludeList.txt)
+{
+    $includeExt = Get-Content $PSScriptRoot\IncludeList.txt | ForEach-Object { $_.Trim() }
     $monitoredExtensions = $monitoredExtensions + $includeExt
 }
 

--- a/DeployCryptoBlocker.ps1
+++ b/DeployCryptoBlocker.ps1
@@ -9,9 +9,9 @@ $fileGroupName = "CryptoBlockerGroup"
 $fileTemplateName = "CryptoBlockerTemplate"
 # set screening type to
 # Active screening: Do not allow users to save unathorized files
-#$fileTemplateType = "Active"
+$fileTemplateType = "Active"
 # Passive screening: Allow users to save unathorized files (use for monitoring)
-$fileTemplateType = "Passiv"
+#$fileTemplateType = "Passiv"
 
 # Write the email options to the temporary file - comment out the entire block if no email notification should be set
 $EmailNotification = $env:TEMP + "\tmpEmail001.tmp"

--- a/DeployCryptoBlocker.ps1
+++ b/DeployCryptoBlocker.ps1
@@ -206,9 +206,9 @@ $monitoredExtensions = @(ConvertFrom-Json20 $jsonStr | ForEach-Object { $_.filte
 # Process SkipList.txt
 Write-Host "`n####"
 Write-Host "Processing SkipList.."
-If (Test-Path .\SkipList.txt)
+If (Test-Path $PSScriptRoot\SkipList.txt)
 {
-    $Exclusions = Get-Content .\SkipList.txt | ForEach-Object { $_.Trim() }
+    $Exclusions = Get-Content $PSScriptRoot\SkipList.txt | ForEach-Object { $_.Trim() }
     $monitoredExtensions = $monitoredExtensions | Where-Object { $Exclusions -notcontains $_ }
 
 }
@@ -228,7 +228,7 @@ Else
 # entries before applying the list to your FSRM implementation.
 #
 '@
-    Set-Content -Path .\SkipList.txt -Value $emptyFile
+    Set-Content -Path $PSScriptRoot\SkipList.txt -Value $emptyFile
 }
 
 # Split the $monitoredExtensions array into fileGroups of less than 4kb to allow processing by filescrn.exe

--- a/DeployCryptoBlocker.ps1
+++ b/DeployCryptoBlocker.ps1
@@ -17,17 +17,21 @@ $fileTemplateType = "Passiv"
 $EmailNotification = $env:TEMP + "\tmpEmail001.tmp"
 "Notification=m" >> $EmailNotification
 "To=[Admin Email]" >> $EmailNotification
-#"Subject=Unauthorized file from the [Violated File Group] file group detected" >> $EmailNotification
-#"Message=User [Source Io Owner] attempted to save [Source File Path] to [File Screen Path] on the [Server] server. This file is in the [Violated File Group] file group, which is not permitted on the server."  >> $EmailNotification
-"Subject=Nicht autorisierte Datei erkannt, die mit Dateigruppe [Violated File Group] übereinstimmt" >> $EmailNotification
-"Message=Das System hat erkannt, dass Benutzer [Source Io Owner] versucht hat, die Datei [Source File Path] unter [File Screen Path] auf Server [Server] zu speichern. Diese Datei weist Übereinstimmungen mit der Dateigruppe [Violated File Group] auf, die auf dem System nicht zulässig ist."  >> $EmailNotification
+## en
+"Subject=Unauthorized file from the [Violated File Group] file group detected" >> $EmailNotification
+"Message=User [Source Io Owner] attempted to save [Source File Path] to [File Screen Path] on the [Server] server. This file is in the [Violated File Group] file group, which is not permitted on the server."  >> $EmailNotification
+## de
+#"Subject=Nicht autorisierte Datei erkannt, die mit Dateigruppe [Violated File Group] übereinstimmt" >> $EmailNotification
+#"Message=Das System hat erkannt, dass Benutzer [Source Io Owner] versucht hat, die Datei [Source File Path] unter [File Screen Path] auf Server [Server] zu speichern. Diese Datei weist Übereinstimmungen mit der Dateigruppe [Violated File Group] auf, die auf dem System nicht zulässig ist."  >> $EmailNotification
 
 # Write the event log options to the temporary file - comment out the entire block if no event notification should be set
 $EventNotification = $env:TEMP + "\tmpEvent001.tmp"
 "Notification=e" >> $EventNotification
 "EventType=Warning" >> $EventNotification
-#"Message=User [Source Io Owner] attempted to save [Source File Path] to [File Screen Path] on the [Server] server. This file is in the [Violated File Group] file group, which is not permitted on the server." >> $EventNotification
-"Message=Das System hat erkannt, dass Benutzer [Source Io Owner] versucht hat, die Datei [Source File Path] unter [File Screen Path] auf Server [Server] zu speichern. Diese Datei weist Übereinstimmungen mit der Dateigruppe [Violated File Group] auf, die auf dem System nicht zulässig ist." >> $EventNotification
+## en
+"Message=User [Source Io Owner] attempted to save [Source File Path] to [File Screen Path] on the [Server] server. This file is in the [Violated File Group] file group, which is not permitted on the server." >> $EventNotification
+## de
+#"Message=Das System hat erkannt, dass Benutzer [Source Io Owner] versucht hat, die Datei [Source File Path] unter [File Screen Path] auf Server [Server] zu speichern. Diese Datei weist Übereinstimmungen mit der Dateigruppe [Violated File Group] auf, die auf dem System nicht zulässig ist." >> $EventNotification
 
 ################################ USER CONFIGURATION ################################
 

--- a/DeployCryptoBlocker.ps1
+++ b/DeployCryptoBlocker.ps1
@@ -1,5 +1,36 @@
 # DeployCryptoBlocker.ps1
-#
+# Version: 1.1
+#####
+
+################################ USER CONFIGURATION ################################
+
+# Names to use in FSRM
+$fileGroupName = "CryptoBlockerGroup"
+$fileTemplateName = "CryptoBlockerTemplate"
+# set screening type to
+# Active screening: Do not allow users to save unathorized files
+#$fileTemplateType = "Active"
+# Passive screening: Allow users to save unathorized files (use for monitoring)
+$fileTemplateType = "Passiv"
+
+# Write the email options to the temporary file - comment out the entire block if no email notification should be set
+$EmailNotification = $env:TEMP + "\tmpEmail001.tmp"
+"Notification=m" >> $EmailNotification
+"To=[Admin Email]" >> $EmailNotification
+#"Subject=Unauthorized file from the [Violated File Group] file group detected" >> $EmailNotification
+#"Message=User [Source Io Owner] attempted to save [Source File Path] to [File Screen Path] on the [Server] server. This file is in the [Violated File Group] file group, which is not permitted on the server."  >> $EmailNotification
+"Subject=Nicht autorisierte Datei erkannt, die mit Dateigruppe [Violated File Group] übereinstimmt" >> $EmailNotification
+"Message=Das System hat erkannt, dass Benutzer [Source Io Owner] versucht hat, die Datei [Source File Path] unter [File Screen Path] auf Server [Server] zu speichern. Diese Datei weist Übereinstimmungen mit der Dateigruppe [Violated File Group] auf, die auf dem System nicht zulässig ist."  >> $EmailNotification
+
+# Write the event log options to the temporary file - comment out the entire block if no event notification should be set
+$EventNotification = $env:TEMP + "\tmpEvent001.tmp"
+"Notification=e" >> $EventNotification
+"EventType=Warning" >> $EventNotification
+#"Message=User [Source Io Owner] attempted to save [Source File Path] to [File Screen Path] on the [Server] server. This file is in the [Violated File Group] file group, which is not permitted on the server." >> $EventNotification
+"Message=Das System hat erkannt, dass Benutzer [Source Io Owner] versucht hat, die Datei [Source File Path] unter [File Screen Path] auf Server [Server] zu speichern. Diese Datei weist Übereinstimmungen mit der Dateigruppe [Violated File Group] auf, die auf dem System nicht zulässig ist." >> $EventNotification
+
+################################ USER CONFIGURATION ################################
+
 ################################ Functions ################################
 
 Function ConvertFrom-Json20
@@ -73,6 +104,8 @@ Function New-CBArraySplit
 
 ################################ Functions ################################
 
+################################ Program code ################################
+
 # Get all drives with shared folders, these drives will get FRSRM protection
 $DrivesContainingShares = @(Get-WmiObject Win32_Share |            # all shares on this computer, filter:
                             Where-Object { $_.Type -eq 0 } |       # 0 = disk drives (not printers, IPC$, C$ Admin shares)
@@ -84,17 +117,20 @@ $DrivesContainingShares = @(Get-WmiObject Win32_Share |            # all shares 
 
 if ($drivesContainingShares.Count -eq 0)
 {
+    Write-Host "`n####"
     Write-Host "No drives containing shares were found. Exiting.."
     exit
 }
 
+Write-Host "`n####"
 Write-Host "The following shares needing to be protected: $($drivesContainingShares -Join ",")"
 
 
-#### Identify Windows Server version, and install FSRM role
+# Identify Windows Server version, and install FSRM role
 $majorVer = [System.Environment]::OSVersion.Version.Major
 $minorVer = [System.Environment]::OSVersion.Version.Minor
 
+Write-Host "`n####"
 Write-Host "Checking File Server Resource Manager.."
 
 Import-Module ServerManager
@@ -106,39 +142,43 @@ if ($majorVer -ge 6)
     if ($minorVer -ge 2 -and $checkFSRM.Installed -ne "True")
     {
         # Server 2012
+        Write-Host "`n####"
         Write-Host "FSRM not found.. Installing (2012).."
         Install-WindowsFeature -Name FS-Resource-Manager -IncludeManagementTools
     }
     elseif ($minorVer -ge 1 -and $checkFSRM.Installed -ne "True")
     {
         # Server 2008 R2
-        Write-Host "FSRM not found.. Installing (2008 R2).."
+        Write-Host "`n####"
+		Write-Host "FSRM not found.. Installing (2008 R2).."
         Add-WindowsFeature FS-FileServer, FS-Resource-Manager
     }
     elseif ($checkFSRM.Installed -ne "True")
     {
         # Server 2008
-        Write-Host "FSRM not found.. Installing (2008).."
+        Write-Host "`n####"
+		Write-Host "FSRM not found.. Installing (2008).."
         &servermanagercmd -Install FS-FileServer FS-Resource-Manager
     }
 }
 else
 {
     # Assume Server 2003
-    Write-Host "Unsupported version of Windows detected! Quitting.."
+    Write-Host "`n####"
+	Write-Host "Unsupported version of Windows detected! Quitting.."
     return
 }
 
-
-$fileGroupName = "CryptoBlockerGroup"
-$fileTemplateName = "CryptoBlockerTemplate"
-$fileScreenName = "CryptoBlockerScreen"
-
 # Download list of CryptoLocker file extensions
+Write-Host "`n####"
+Write-Host "Dowloading CryptoLocker file extensions list from fsrm.experiant.ca api.."
 $webClient = New-Object System.Net.WebClient
 $jsonStr = $webClient.DownloadString("https://fsrm.experiant.ca/api/v1/get")
 $monitoredExtensions = @(ConvertFrom-Json20 $jsonStr | ForEach-Object { $_.filters })
 
+# Process SkipList.txt
+Write-Host "`n####"
+Write-Host "Processing SkipList.."
 If (Test-Path .\SkipList.txt)
 {
     $Exclusions = Get-Content .\SkipList.txt | ForEach-Object { $_.Trim() }
@@ -164,47 +204,57 @@ Else
     Set-Content -Path .\SkipList.txt -Value $emptyFile
 }
 
-
 # Split the $monitoredExtensions array into fileGroups of less than 4kb to allow processing by filescrn.exe
 $fileGroups = @(New-CBArraySplit $monitoredExtensions)
 
 # Perform these steps for each of the 4KB limit split fileGroups
+Write-Host "`n####"
+Write-Host "Adding/replacing File Groups.."
 ForEach ($group in $fileGroups) {
-    Write-Host "Adding/replacing File Group [$($group.fileGroupName)] with monitored file [$($group.array -Join ",")].."
-    &filescrn.exe filegroup Delete "/Filegroup:$($group.fileGroupName)" /Quiet
+    #Write-Host "Adding/replacing File Group [$($group.fileGroupName)] with monitored file [$($group.array -Join ",")].."
+    Write-Host "`nFile Group [$($group.fileGroupName)] with monitored files from [$($group.array[0])] to [$($group.array[$group.array.GetUpperBound(0)])].."
+	&filescrn.exe filegroup Delete "/Filegroup:$($group.fileGroupName)" /Quiet
     &filescrn.exe Filegroup Add "/Filegroup:$($group.fileGroupName)" "/Members:$($group.array -Join '|')"
 }
 
-Write-Host "Adding/replacing File Screen Template [$fileTemplateName] with Event Notification [$eventConfFilename] and Command Notification [$cmdConfFilename].."
+# Create File Screen Template with Notification
+Write-Host "`n####"
+Write-Host "Adding/replacing [$fileTemplateType] File Screen Template [$fileTemplateName] with eMail Notification [$EmailNotification] and Event Notification [$EventNotification].."
 &filescrn.exe Template Delete /Template:$fileTemplateName /Quiet
-# Build the argument list with all required fileGroups
-$screenArgs = 'Template', 'Add', "/Template:$fileTemplateName"
+# Build the argument list with all required fileGroups and notifications
+$screenArgs = 'Template', 'Add', "/Template:$fileTemplateName", "/Type:$fileTemplateType"
 ForEach ($group in $fileGroups) {
     $screenArgs += "/Add-Filegroup:$($group.fileGroupName)"
 }
-
+If ($EmailNotification -ne "") {
+    $screenArgs += "/Add-Notification:m,$EmailNotification"
+}
+If ($EventNotification -ne "") {
+    $screenArgs += "/Add-Notification:e,$EventNotification"
+}
 &filescrn.exe $screenArgs
 
-$EmailNotification = $env:TEMP + "\tmpEmail001.tmp"
-$EventNotification = $env:TEMP + "\tmpEvent001.tmp"
-
-# Write the email options to the temporary file
-"Notification=m" >> $EmailNotification
-"To=[Admin Email]" >> $EmailNotification
-"Subject=Unauthorized file from the [Violated File Group] file group detected" >> $EmailNotification
-"Message=User [Source Io Owner] attempted to save [Source File Path] to [File Screen Path] on the [Server] server. This file is in the [Violated File Group] file group, which is not permitted on the server."  >> $EmailNotification
-
-# Write the event log options to the temporary file
-"Notification=e" >> $EventNotification
-"EventType=Warning" >> $EventNotification
-"Message=User [Source Io Owner] attempted to save [Source File Path] to [File Screen Path] on the [Server] server. This file is in the [Violated File Group] file group, which is not permitted on the server." >> $EventNotification
-
+# Create File Screens for every drive containing shares
+Write-Host "`n####"
 Write-Host "Adding/replacing File Screens.."
 $drivesContainingShares | ForEach-Object {
-    Write-Host "`tAdding/replacing File Screen for [$_] with Source Template [$fileTemplateName].."
+    Write-Host "File Screen for [$_] with Source Template [$fileTemplateName].."
     &filescrn.exe Screen Delete "/Path:$_" /Quiet
-    &filescrn.exe Screen Add "/Path:$_" "/SourceTemplate:$fileTemplateName" "/Add-Notification:m,$EmailNotification" "/Add-Notification:e,$EventNotification"
+    &filescrn.exe Screen Add "/Path:$_" "/SourceTemplate:$fileTemplateName"
 }
 
-Remove-Item $EmailNotification -Force
-Remove-Item $EventNotification -Force
+# Cleanup temporary files if they were created
+Write-Host "`n####"
+Write-Host "Cleaning up temporary stuff.."
+If ($EmailNotification -ne "") {
+	Remove-Item $EmailNotification -Force
+}
+If ($EventNotification -ne "") {
+	Remove-Item $EventNotification -Force
+}
+
+Write-Host "`n####"
+Write-Host "Done."
+Write-Host "####"
+
+################################ Program code ################################


### PR DESCRIPTION
Adding the Exclusion only worked for the first time the script was executed. The Exception was added but never updated and needs to be recreated after the rebuild of the CryptoBlocker FileGroups.

I changed the script to delete the Exception first and recreate it afterwards.